### PR TITLE
Unassigning Exams

### DIFF
--- a/02_Routes/Exams/ExamInfoController.js
+++ b/02_Routes/Exams/ExamInfoController.js
@@ -126,7 +126,9 @@ const updateExamInfo = async (req, res) => {
 					// insert/update answer contexts
 					let before_index = 0;
 					let after_index = 0;
-					answer_contexts?.forEach(async (c) => {
+
+					// need to use for...of loop to ensure order insertion for answer index ordering
+					for (const c of answer_contexts) {
 						if (c.answer_field_id === a.answer_field_id) {
 							c.new
 								? await knex(postAnswerContextsDB).insert({
@@ -158,7 +160,7 @@ const updateExamInfo = async (req, res) => {
 								after_index += 1;
 							}
 						}
-					});
+					}
 				}
 			});
 		});

--- a/02_Routes/Exams/v1ExamsRouter.js
+++ b/02_Routes/Exams/v1ExamsRouter.js
@@ -15,10 +15,11 @@ router.post('', authorize({}), ExamsController.createExam);
 router.put('', authorize({}), ExamsController.updateExam);
 
 router.get('/assigned', authorize({}), AssignedExamsController.getExamsAssignedToUser);
-router.put('/assigned', authorize({}), AssignedExamsController.gradeAssignedExam);
+router.put('/assigned', authorize({}), AssignedExamsController.unassignExam);
 router.post('/assigned', authorize({}), AssignedExamsController.assignExams);
 router.get('/assigned/users', authorize({}), AssignedExamsController.getUsersAssignedToExam);
 router.get('/assigned/taking', authorize({}), AssignedExamsController.getExamUserIsTaking);
+router.put('/assigned/taking', authorize({}), AssignedExamsController.gradeExamUserIsTaking);
 
 router.get('/history', authorize({}), ExamHistoryController.getExamHistory);
 


### PR DESCRIPTION
- Updated assigned exam GET endpoints to use 'pending' instead of 'incompleted'
- Updated assigned exam GET endpoints to use an added 'deleted' boolean field in assigned_exams table, allowing for exams to be assigned/unassigned/reassigned properly
- Assigned exam users GET endpoint 'unassigned' now gets users that both have never been assigned an exam and those have have completed and passed it, allowing reassignment of exams
- Added PUT endpoint to allow unassigning of exams
- Reorganized assigned exam endpoints